### PR TITLE
Speed up write step

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -5,6 +5,7 @@ export {
 export { parse as flagsParse } from "https://deno.land/std@0.178.0/flags/mod.ts";
 export {
   emptyDirSync,
+  ensureDir,
   ensureDirSync,
   walk,
   type WalkEntry,


### PR DESCRIPTION
👋 @kkga 

In [todo.md](https://github.com/kkga/ter/blob/aeff34bc06a95f26f7360b3ec15c6df50e10cb7e/docs/todo.md), I saw:

> use streams to open and write markdown files

<br>

This PR makes the write step run concurrently rather than writing each output file one-by-one.

In my testing, it saves a few seconds for very large projects.

There's no pressure to merge this, it's not blocking me, etc.

I'm just sharing it in case it's interesting!