### PR TITLE
Add getChildPages optimization

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -144,8 +144,7 @@ async function generateSite(opts: GenerateSiteOpts) {
     ...pages.map((page) => {
       const writePath = join(outputPath, page.url.pathname, "index.html");
       const listedPages = pages.filter((p) => !p.unlisted);
-      const childPages = getChildPages(listedPages, page);
-      const allChildPages = getChildPages(listedPages, page, true);
+      const { childPages, allChildPages } = getChildPages(listedPages, page);
       const backlinkPages = getBacklinkPages(listedPages, page);
       const childTags = getTags(allChildPages);
       const childPagesByTag = getPagesByTags(listedPages, childTags);

--- a/pages.ts
+++ b/pages.ts
@@ -117,14 +117,19 @@ function getRelatedPages(pages: Page[], current: Page): Page[] {
   );
 }
 
-function getChildPages(pages: Page[], current: Page, deep?: boolean): Page[] {
-  return pages.filter(
-    (p) =>
-      current.url.pathname !== p.url.pathname &&
-      (deep
-        ? p.url.pathname.startsWith(current.url.pathname)
-        : current.url.pathname === dirname(p.url.pathname))
-  );
+function getChildPages(pages: Page[], current: Page): {childPages: Page[], allChildPages: Page[]} {
+  const childPages: Page[] = [];
+  const allChildPages: Page[] = [];
+  pages.forEach(p => {
+    if (current.url.pathname !== p.url.pathname) {
+      if (current.url.pathname === dirname(p.url.pathname)) {
+        childPages.push(p)
+      } else if (p.url.pathname.startsWith(current.url.pathname)) {
+        allChildPages.push(p)
+      }
+    }
+  });
+  return { childPages, allChildPages }
 }
 
 function getPagesByTags(

--- a/pages.ts
+++ b/pages.ts
@@ -117,7 +117,7 @@ function getRelatedPages(pages: Page[], current: Page): Page[] {
   );
 }
 
-function getChildPages(pages: Page[], current: Page): {childPages: Page[], allChildPages: Page[]} {
+function getChildPages(pages: Page[], current: Page): { childPages: Page[], allChildPages: Page[] } {
   const childPages: Page[] = [];
   const allChildPages: Page[] = [];
   pages.forEach(p => {


### PR DESCRIPTION
👋 @kkga 

This `getChildPages` optimization speeds up the 10k markdown file benchmark by 20-30sec on my M1 Pro.

I traced the benchmark and saw we were spending 60sec in this function:

<img width="456" alt="Screenshot 2023-04-19 at 20 58 59" src="https://user-images.githubusercontent.com/34559231/233186328-6ec05c43-056a-4ca8-b618-9b1fc159497d.png">

We call `getChildPages` twice per page and end up doing duplicate work (looping the other pages).

This PR roughly halves the amount of time we spend in this function.

There are no performance benefits for small builds (e.g. docs).

As always, no pressure to merge this – just sharing for interest :)

### Benchmark used

```
git clone https://github.com/Zettelkasten-Method/10000-markdown-files
time deno run -A --unstable main.ts --input 10000-markdown-files
```